### PR TITLE
(feat): Display Audit Logs module in Admin UI

### DIFF
--- a/omod/src/main/java/org/openmrs/module/auditlogweb/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/extension/html/AdminList.java
@@ -25,7 +25,7 @@ public class AdminList extends AdministrationSectionExt {
 	 * @see org.openmrs.module.web.extension.AdministrationSectionExt#getTitle()
 	 */
 	public String getTitle() {
-		return "auditlogweb.title";
+		return "Audit Logs Module";
 	}
 	
 	/**
@@ -34,9 +34,7 @@ public class AdminList extends AdministrationSectionExt {
 	public Map<String, String> getLinks() {
 		
 		Map<String, String> map = new HashMap<String, String>();
-		
-		map.put("module/auditlogweb/auditlogweb.form", "auditlogweb.title");
-		
+		map.put("module/auditlogweb/auditlogweb.form", "View Audit Trails");
 		return map;
 	}
 	

--- a/omod/src/main/java/org/openmrs/module/auditlogweb/extension/html/AdminList.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/extension/html/AdminList.java
@@ -25,7 +25,7 @@ public class AdminList extends AdministrationSectionExt {
 	 * @see org.openmrs.module.web.extension.AdministrationSectionExt#getTitle()
 	 */
 	public String getTitle() {
-		return "Audit Logs Module";
+		return "auditlogweb.title";
 	}
 	
 	/**

--- a/omod/src/main/resources/messages.properties
+++ b/omod/src/main/resources/messages.properties
@@ -1,0 +1,1 @@
+auditlogweb.title=Audit Logs Module

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
-		<groupId>org.openmrs.maven.parents</groupId>
-		<artifactId>maven-parent-openmrs-module</artifactId>
-		<version>1.1.1</version>
-	</parent>
+
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>auditlogweb</artifactId>
 	<version>1.0.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-
+	<parent>
+		<groupId>org.openmrs.maven.parents</groupId>
+		<artifactId>maven-parent-openmrs-module</artifactId>
+		<version>1.1.1</version>
+	</parent>
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>auditlogweb</artifactId>
 	<version>1.0.0-SNAPSHOT</version>


### PR DESCRIPTION
This PR adds a minimal implementation to display the Audit Logs module in the OpenMRS Admin UI. It introduces an admin section with a link to view audit trails, making the module accessible from the administration page. No advanced UI or business logic is included at this stage.