### PR TITLE
(Fix): Register AuditServiceImpl as a Spring service bean

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
@@ -15,10 +15,13 @@ import org.openmrs.module.auditlogweb.api.AuditService;
 import org.openmrs.module.auditlogweb.api.dao.AuditDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
 import java.util.ArrayList;
 import java.util.List;
 
 @RequiredArgsConstructor
+@Service
 public class AuditServiceImpl extends BaseOpenmrsService implements AuditService {
 
     private final Logger log = LoggerFactory.getLogger(AuditServiceImpl.class);


### PR DESCRIPTION

#### PR description:
This PR adds the `@Service` annotation to the AuditServiceImpl class, ensuring it is registered as a Spring bean. This resolves the NoSuchBeanDefinitionException for AuditService during dependency injection.