### PR TITLE
chore(ui): remove 'Audit Log Details' link from header tabs

### DIFF
--- a/omod/src/main/webapp/localHeader.jsp
+++ b/omod/src/main/webapp/localHeader.jsp
@@ -13,8 +13,5 @@
     <li <c:if test='${page eq "auditlogs"}'>class="active"</c:if>>
         <a href="${pageContext.request.contextPath}/module/auditlogweb/auditlogs.form">Audit Logs</a>
     </li>
-    <li <c:if test='${page eq "viewAudit"}'>class="active"</c:if>>
-        <a href="${pageContext.request.contextPath}/module/auditlogweb/viewAudit.form">Audit Log Detail</a>
-    </li>
     <!-- Add more tabs as needed -->
 </ul>


### PR DESCRIPTION
#### Ticket:  [audit-21](https://openmrs.atlassian.net/browse/AUDIT-21)

### PR Description
This PR removes the "Audit Log Details" tab from the application’s header navigation to clean up the UI and improve user focus. This tab is no longer needed as it's associated to the Audit Logs and not independet.