### PR TITLE
AUDIT-31: Fix null/empty/unreadable values in audit log field display

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/utils/UtilClass.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/utils/UtilClass.java
@@ -8,6 +8,22 @@
  */
 package org.openmrs.module.auditlogweb.api.utils;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.persistence.MappedSuperclass;
+
 import org.hibernate.envers.Audited;
 import org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff;
 import org.reflections.Reflections;
@@ -16,22 +32,6 @@ import org.reflections.util.ClasspathHelper;
 import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.persistence.Entity;
-import javax.persistence.MappedSuperclass;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.Set;
-import java.util.ArrayList;
-import java.util.Objects;
-import java.util.Date;
-import java.util.stream.Collectors;
-import java.util.Collections;
 
 /**
  * Utility class providing methods for working with Envers-audited classes,
@@ -91,45 +91,68 @@ public class UtilClass {
      * @return a list of {@link AuditFieldDiff} showing name, old value, new value, and change flag
      */
     public static List<AuditFieldDiff> computeFieldDiffs(Class<?> clazz, Object oldEntity, Object currentEntity) {
-        List<AuditFieldDiff> diffs = new ArrayList<>();
-        if (currentEntity == null) return diffs;
+    List<AuditFieldDiff> diffs = new ArrayList<>();
+    if (currentEntity == null) return diffs;
 
-        Field[] fields = clazz.getDeclaredFields();
-        for (Field field : fields) {
-            if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) continue;
+    Field[] fields = clazz.getDeclaredFields();
+    for (Field field : fields) {
+        if (Modifier.isStatic(field.getModifiers()) || field.isSynthetic()) continue;
 
-            field.setAccessible(true);
+        field.setAccessible(true);
 
-            String oldVal = null;
-            String currVal = null;
-            boolean failedOld = false;
-            boolean failedCurr = false;
+        String oldVal = null;
+        String currVal = null;
 
-            try {
-                currVal = String.valueOf(field.get(currentEntity));
-            } catch (Exception e) {
-                log.warn("Failed to read current value of field '{}': {}", field.getName(), e.getMessage());
-                failedCurr = true;
-            }
-
-            try {
-                oldVal = oldEntity != null ? String.valueOf(field.get(oldEntity)) : null;
-            } catch (Exception e) {
-                log.warn("Failed to read old value of field '{}': {}", field.getName(), e.getMessage());
-                failedOld = true;
-            }
-
-            if (failedOld || failedCurr) {
-                log.debug("Setting field '{}' values to 'Unable to read' due to access failure", field.getName());
-                oldVal = currVal = "Unable to read";
-            }
-
-            boolean isDifferent = !Objects.equals(oldVal, currVal);
-            diffs.add(new AuditFieldDiff(field.getName(), oldVal, currVal, isDifferent));
+        try {
+            Object currRaw = field.get(currentEntity);
+            currVal = toSafeString(currRaw);
+        } catch (Exception e) {
+            log.warn("Failed to read current value of field '{}': {}", field.getName(), e.getMessage());
+            currVal = "[Unable to read]";
         }
-        return diffs;
-    }
 
+        try {
+            if (oldEntity != null) {
+                Object oldRaw = field.get(oldEntity);
+                oldVal = toSafeString(oldRaw);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to read old value of field '{}': {}", field.getName(), e.getMessage());
+            oldVal = "[Unable to read]";
+        }
+
+        boolean isDifferent = !Objects.equals(oldVal, currVal);
+        diffs.add(new AuditFieldDiff(field.getName(), oldVal, currVal, isDifferent));
+    }
+    return diffs;
+}
+
+/**
+ * Safely converts a field value to a human-readable string.
+ * Handles null values, Hibernate proxies, and complex objects gracefully.
+ *
+ * @param value the raw field value
+ * @return a safe string representation, or "[No value]" if null
+ */
+private static String toSafeString(Object value) {
+    if (value == null) {
+        return "[No value]";
+    }
+    try {
+        // Try getId() first for OpenMRS domain objects (Patient, User, etc.)
+        try {
+            Object id = value.getClass().getMethod("getId").invoke(value);
+            String simpleName = value.getClass().getSimpleName();
+            return simpleName + "(id=" + id + ")";
+        } catch (NoSuchMethodException ignored) {
+            // Not an OpenMRS domain object, fall through
+        }
+        return value.toString();
+    } catch (Exception e) {
+        log.warn("Could not convert field value to string: {}", e.getMessage());
+        return "[Unable to read]";
+    }
+}
     /**
      * Computes the total number of pages for a paginated dataset.
      *

--- a/api/src/test/java/org/openmrs/module/auditlogweb/api/utils/UtilClassUnitTest.java
+++ b/api/src/test/java/org/openmrs/module/auditlogweb/api/utils/UtilClassUnitTest.java
@@ -8,18 +8,18 @@
  */
 package org.openmrs.module.auditlogweb.api.utils;
 
-import org.hibernate.envers.Audited;
-import org.junit.jupiter.api.Test;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.hibernate.envers.Audited;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
 
 
 public class UtilClassUnitTest {
@@ -70,4 +70,81 @@ public class UtilClassUnitTest {
     public static class TestAuditedClass {}
 
     public static class NotAuditedClass {}
+    
+    @Test
+    public void computeFieldDiffs_shouldReturnNoValueForNullFields() {
+        SampleEntity old = new SampleEntity(null, "old@email.com");
+        SampleEntity current = new SampleEntity(null, "new@email.com");
+
+        List<org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff> diffs =
+                UtilClass.computeFieldDiffs(SampleEntity.class, old, current);
+
+        // null field should display as "[No value]" not the string "null"
+        diffs.stream()
+                .filter(d -> d.getFieldName().equals("name"))
+                .forEach(d -> {
+                    assertEquals("[No value]", d.getOldValue());
+                    assertEquals("[No value]", d.getCurrentValue());
+                });
+    }
+
+    @Test
+    public void computeFieldDiffs_shouldDetectChangedFields() {
+        SampleEntity old = new SampleEntity("Alice", "alice@email.com");
+        SampleEntity current = new SampleEntity("Bob", "alice@email.com");
+
+        List<org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff> diffs =
+                UtilClass.computeFieldDiffs(SampleEntity.class, old, current);
+
+        org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff nameDiff = diffs.stream()
+                .filter(d -> d.getFieldName().equals("name"))
+                .findFirst().orElse(null);
+
+        assertNotNull(nameDiff);
+        assertTrue(nameDiff.isChanged());
+        assertEquals("Alice", nameDiff.getOldValue());
+        assertEquals("Bob", nameDiff.getCurrentValue());
+    }
+
+    @Test
+    public void computeFieldDiffs_shouldNotMarkUnchangedFieldsAsChanged() {
+        SampleEntity old = new SampleEntity("Alice", "alice@email.com");
+        SampleEntity current = new SampleEntity("Alice", "alice@email.com");
+
+        List<org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff> diffs =
+                UtilClass.computeFieldDiffs(SampleEntity.class, old, current);
+
+        diffs.forEach(d -> assertFalse(d.isChanged()));
+    }
+
+    @Test
+    public void computeFieldDiffs_shouldHandleNullOldEntity() {
+        SampleEntity current = new SampleEntity("Alice", "alice@email.com");
+
+        List<org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff> diffs =
+                UtilClass.computeFieldDiffs(SampleEntity.class, null, current);
+
+        // All fields should be marked changed (old is null, current has values)
+        assertFalse(diffs.isEmpty());
+        diffs.forEach(d -> assertNull(d.getOldValue()) );
+    }
+
+    @Test
+    public void computeFieldDiffs_shouldReturnEmptyListForNullCurrentEntity() {
+        List<org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff> diffs =
+                UtilClass.computeFieldDiffs(SampleEntity.class, null, null);
+
+        assertTrue(diffs.isEmpty());
+    }
+
+    // Simple test entity — no Hibernate, no OpenMRS dependencies
+    public static class SampleEntity {
+        private String name;
+        private String email;
+
+        public SampleEntity(String name, String email) {
+            this.name = name;
+            this.email = email;
+        }
+    }
 }


### PR DESCRIPTION
## AUDIT-31: Fix null/empty/unreadable values in audit log field display

## Problem
The audit log viewer was displaying raw "null" strings and blank values 
for changed fields. This happened because:
1. String.valueOf(null) produces the literal string "null" not a blank
2. OpenMRS domain object fields (Patient, User, Location etc.) triggered 
   Hibernate proxy loading which failed silently, showing nothing
3. If either old OR current value failed to read, BOTH were overwritten 
   with "Unable to read", losing valid data

## Description of what I changed

- Replaced String.valueOf() with a null-safe toSafeString() helper
- Null field values now show [No value] instead of the literal string "null"
- OpenMRS domain objects (Patient, User, Location) now show Type(id=X)
  instead of triggering Hibernate proxy errors that caused blank values
- Old and current value failures are now handled independently so one
  broken field doesn't wipe out the other


## Issue I worked on

see https://openmrs.atlassian.net/browse/AUDIT-31

## Checklist: I completed these to help reviewers :)
- [x] Code style followed
- [x] Tests added (5 new unit tests in UtilClassUnitTest)
- [x] mvn clean package passed
- [x] All tests passed
- [x] Based on latest main branch