### PR TITLE
AUDIT-28: Fix missing audit data when paginating across multiple entity types

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/dao/AuditDao.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/dao/AuditDao.java
@@ -8,7 +8,13 @@
  */
 package org.openmrs.module.auditlogweb.api.dao;
 
-import lombok.RequiredArgsConstructor;
+import java.lang.reflect.Modifier;
+import java.sql.SQLSyntaxErrorException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.hibernate.SessionFactory;
 import org.hibernate.envers.AuditReader;
 import org.hibernate.envers.AuditReaderFactory;
@@ -16,6 +22,8 @@ import org.hibernate.envers.RevisionType;
 import org.hibernate.envers.exception.NotAuditedException;
 import org.hibernate.envers.query.AuditQuery;
 import org.hibernate.exception.SQLGrammarException;
+import org.openmrs.GlobalProperty;
+import org.openmrs.Role;
 import org.openmrs.api.db.hibernate.envers.OpenmrsRevisionEntity;
 import org.openmrs.module.auditlogweb.AuditEntity;
 import org.openmrs.module.auditlogweb.api.utils.EnversUtils;
@@ -24,15 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
 
-import org.openmrs.GlobalProperty;
-import org.openmrs.Role;
-
-import java.lang.reflect.Modifier;
-import java.sql.SQLSyntaxErrorException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Date;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Data access object (DAO) for retrieving audit log information using Hibernate Envers.
@@ -348,29 +348,26 @@ public class AuditDao {
     }
 
     private List<AuditEntity<?>> fetchAcrossEntities(List<Class<?>> classes, Integer userId, Date startDate, Date endDate, String sortOrder, int page, int size) {
+    // Fetch enough records from each entity to cover the requested page.
+    // We use (page + 1) * size as the fetch window so earlier pages are not skipped.
+    int fetchSize = (page + 1) * size;
 
-        // NOTE: We fetch (page * size) revisions from each audited entity type here.
-        // This results in potentially thousands of records being loaded into memory, if many entity types exist. Sorting and pagination are applied
-        // in-memory after combining all results, which can be inefficient.
-        // TODO: Optimize by performing sorting and pagination at the database level across all entity types,
-        // possibly by writing a native SQL union query or adding an audit summary table.
-
-        List<AuditEntity<?>> combined = new ArrayList<>();
-        for (Class<?> clazz : classes) {
-            try {
-                List<? extends AuditEntity<?>> revisions = getRevisionsWithFilters(
-                        clazz, page, size, userId, startDate, endDate, sortOrder);
-                combined.addAll(revisions);
-            } catch (Exception ex) {
-                if (isMissingAuditTableException(ex)) {
-                    log.warn("Skipping class {} due to missing audit table or SQL error: {}", clazz.getName(), ex.getMessage());
-                } else {
-                    log.error("Unexpected error while fetching audit logs for class {}: {}", clazz.getName(), ex.getMessage(), ex);
-                }
+    List<AuditEntity<?>> combined = new ArrayList<>();
+    for (Class<?> clazz : classes) {
+        try {
+            List<? extends AuditEntity<?>> revisions = getRevisionsWithFilters(
+                    clazz, 0, fetchSize, userId, startDate, endDate, sortOrder);
+            combined.addAll(revisions);
+        } catch (Exception ex) {
+            if (isMissingAuditTableException(ex)) {
+                log.warn("Skipping class {} due to missing audit table or SQL error: {}", clazz.getName(), ex.getMessage());
+            } else {
+                log.error("Unexpected error while fetching audit logs for class {}: {}", clazz.getName(), ex.getMessage(), ex);
             }
         }
-        return combined;
     }
+    return combined;
+}
 
     private long countAcrossEntities(List<Class<?>> classes, Integer userId, Date startDate, Date endDate) {
         return classes.stream().mapToLong(clazz -> {


### PR DESCRIPTION
## AUDIT-28: Fix missing audit log entries across paginated entity types

## Description of what I changed

The `fetchAcrossEntities` method in `AuditDao` was passing the user's 
requested `page` and `size` directly to each individual entity query. 
This caused records from entity types with small record counts to be 
completely skipped before the combined sort and pagination step.

Fixed by changing the per-entity fetch to always start from page 0 
and use a window of `(page + 1) * size` records, ensuring all relevant 
records from every entity type are included before final pagination.


## Issue I worked on
see https://openmrs.atlassian.net/browse/AUDIT-28


## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch. --rebase upstream master`