### PR TITLE
fix: add missing @param javadoc, null check, and remove leftover dev comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation
 2. Use the OpenMRS Administration > Manage Modules screen to upload and install the .omod file.
 
 Alternative Installation Method: 
-If OpenMRS SDk is installed, you can use the following command to install the module:
+If OpenMRS SDK is installed, you can use the following command to install the module:
 ```
 mvn openmrs-sdk:deploy -DserverId={serverName} -DmoduleVersion=1.0.0-SNAPSHOT
 ```
@@ -48,7 +48,7 @@ mvn openmrs-sdk:watch -DserverId={serverName} -DmoduleVersion=1.0.0-SNAPSHOT
 ```
 This will automatically deploy changes to the module without needing to manually upload the .omod file each time.
 
-If uploads are not allowed from the web (changable via a runtime property), you can drop the omod
+If uploads are not allowed from the web (changeable via a runtime property), you can drop the omod
 into the ~/.OpenMRS/modules folder.  (Where ~/.OpenMRS is assumed to be the Application 
 Data Directory that the running openmrs is currently using.)  After putting the file in there 
 simply restart OpenMRS/tomcat and the module will be loaded and started.

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/AuditService.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/AuditService.java
@@ -35,6 +35,7 @@ public interface AuditService {
      * @param page        the page number (zero-based)
      * @param size        the number of results per page
      * @param <T>         the type of the audited entity
+     * @param sortOrder   the sort direction ("asc" or "desc")
      * @return a list of {@link AuditEntity} representing revisions of the entity
      */
     @Authorized(AuditLogConstants.VIEW_AUDIT_LOGS)
@@ -48,6 +49,7 @@ public interface AuditService {
      * @param page            the page number (zero-based)
      * @param size            the number of results per page
      * @param <T>             the type of the audited entity
+     * @param sortOrder   the sort direction ("asc" or "desc")
      * @return a list of {@link AuditEntity} representing revisions of the entity,
      *         or an empty list if the class is not found
      */

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
@@ -271,6 +271,7 @@ public class AuditServiceImpl extends BaseOpenmrsService implements AuditService
      */
     @Override
     public List<AuditLogDetailDTO> mapAuditEntitiesToDetails(List<AuditEntity<?>> auditEntities) {
+        if (auditEntities == null) return new ArrayList<>();
         List<AuditLogDetailDTO> dtoList = new ArrayList<>();
 
         for (AuditEntity<?> entity : auditEntities) {

--- a/omod/src/main/java/org/openmrs/module/auditlogweb/web/controller/AuditlogwebController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/web/controller/AuditlogwebController.java
@@ -161,7 +161,7 @@ public class AuditlogwebController {
             @RequestParam(value = "endDate", required = false) String endDateStr,
             @RequestParam(value = "page", defaultValue = "0") int page,
             @RequestParam(value = "size", defaultValue = "15") int size,
-            @RequestParam(value = "sortOrder", defaultValue = "desc") String sortOrder,   // <-- New param
+            @RequestParam(value = "sortOrder", defaultValue = "desc") String sortOrder,  
             Model model) {
 
         if (!EnversUtils.isEnversEnabled()) {


### PR DESCRIPTION
1. AuditService.java
   - Added missing @param sortOrder in Javadoc for both getAllRevisions() overloads

2. AuditServiceImpl.java
   - Added null check in mapAuditEntitiesToDetails() to prevent 
     NullPointerException when null list is passed

3. AuditlogwebController.java
   - Removed leftover inline dev comment "// <-- New param" from line 164