### PR TITLE
AUDIT-32: Improve search experience with sortOrder, action filter and entity type search

### DIFF
--- a/omod/src/main/java/org/openmrs/module/auditlogweb/rest/AuditLogRestController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/rest/AuditLogRestController.java
@@ -8,7 +8,12 @@
  */
 package org.openmrs.module.auditlogweb.rest;
 
-import lombok.RequiredArgsConstructor;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.auditlogweb.api.AuditService;
@@ -17,17 +22,13 @@ import org.openmrs.module.auditlogweb.api.dto.AuditLogResponseDto;
 import org.openmrs.module.auditlogweb.api.utils.AuditLogConstants;
 import org.openmrs.module.webservices.rest.web.RestConstants;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 /**
  * REST controller for exposing audit log entries via the OpenMRS REST API.
@@ -72,26 +73,43 @@ public class AuditLogRestController {
             @RequestParam(required = false) String username,
             @RequestParam(required = false) String startDate,
             @RequestParam(required = false) String endDate,
-            @RequestParam(required = false) String entityType
+            @RequestParam(required = false) String entityType,
+            @RequestParam(defaultValue = "desc") String sortOrder,
+            @RequestParam(required = false) String action
     ) {
         if (page < 0) page = 0;
         if (size <= 0) size = 20;
+        if (!sortOrder.equalsIgnoreCase("asc") && !sortOrder.equalsIgnoreCase("desc")) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "Invalid sortOrder: '" + sortOrder + "'. Expected 'asc' or 'desc'");
+        }
 
         Integer effectiveUserId = resolveUserId(userId, username);
         Date start = parseDate(startDate);
         Date end = parseDate(endDate);
 
-        boolean fullDetails = userId != null || username != null || startDate != null || endDate != null || entityType != null;
+        boolean fullDetails = userId != null || username != null || startDate != null
+                || endDate != null || entityType != null || action != null;
 
         List<AuditLogDetailDTO> auditDetails = auditService.mapAuditEntitiesToDetails(
-                auditService.getAllRevisionsAcrossEntitiesWithEntityType(page, size, effectiveUserId, start, end, entityType, "desc")
+                auditService.getAllRevisionsAcrossEntitiesWithEntityType(
+                        page, size, effectiveUserId, start, end, entityType, sortOrder)
         );
+
+        if (action != null && !action.trim().isEmpty()) {
+            String upperAction = action.trim().toUpperCase();
+            auditDetails = auditDetails.stream()
+                    .filter(d -> d.getEventType() != null &&
+                            d.getEventType().toUpperCase().contains(upperAction))
+                    .collect(java.util.stream.Collectors.toList());
+        }
 
         if (!fullDetails) {
             auditDetails.forEach(d -> d.setChanges(Collections.emptyList()));
         }
 
-        long total = auditService.countRevisionsAcrossEntitiesWithEntityType(effectiveUserId, start, end, entityType);
+        long total = auditService.countRevisionsAcrossEntitiesWithEntityType(
+                effectiveUserId, start, end, entityType);
         int totalPages = (int) Math.ceil(total / (double) size);
 
         return new AuditLogResponseDto(Math.toIntExact(total), page, totalPages, auditDetails);

--- a/omod/src/main/java/org/openmrs/module/auditlogweb/web/service/AuditLogViewService.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/web/service/AuditLogViewService.java
@@ -8,7 +8,9 @@
  */
 package org.openmrs.module.auditlogweb.web.service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.Date;
+import java.util.List;
+
 import org.openmrs.module.auditlogweb.AuditEntity;
 import org.openmrs.module.auditlogweb.api.AuditService;
 import org.openmrs.module.auditlogweb.api.utils.UtilClass;
@@ -16,9 +18,7 @@ import org.openmrs.module.auditlogweb.web.dto.AuditFilter;
 import org.openmrs.module.auditlogweb.web.dto.PaginatedAuditResult;
 import org.springframework.stereotype.Component;
 
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Service class responsible for preparing audit log data for display in the UI.
@@ -55,7 +55,15 @@ public class AuditLogViewService {
         }
         return (List<AuditEntity<?>>)(List<?>) auditService.getAllRevisions(clazz, page, size, sortOrder);
     }
+    public List<AuditEntity<?>> fetchAuditLogs(Class<?> clazz, int page, int size, Integer userId, Date startDate, Date endDate, String sortOrder) {
+    boolean hasFilters = userId != null || startDate != null || endDate != null;
 
+    if (hasFilters) {
+        return (List<AuditEntity<?>>)(List<?>) auditService.getRevisionsWithFilters(
+                clazz, page, size, userId, startDate, endDate, sortOrder);
+    }
+    return (List<AuditEntity<?>>)(List<?>) auditService.getAllRevisions(clazz, page, size, sortOrder);
+}
     /**
      * Counts the total number of audit log entries for the given audited entity class,
      * optionally filtered by user and date range.
@@ -119,15 +127,17 @@ public class AuditLogViewService {
 
         if (domainClassName != null && !domainClassName.isEmpty()) {
             Class<?> clazz = Class.forName(domainClassName);
-            List<AuditEntity<?>> audits = fetchAuditLogs(clazz, page, size, username, filters.getStartDate(), filters.getEndDate(), sortOrder);
+            List<AuditEntity<?>> audits = fetchAuditLogs(clazz, page, size, filters.getUserId(), filters.getStartDate(), filters.getEndDate(), sortOrder);
             long totalCount = countAuditLogs(clazz, username, filters.getStartDate(), filters.getEndDate());
             return new PaginatedAuditResult(audits, totalCount);
         } else {
-            List<AuditEntity<?>> audits = auditService.getAllRevisionsAcrossEntities(page, size, filters.getUserId(), filters.getStartDate(), filters.getEndDate(), sortOrder);
-            long totalCount = auditService.countRevisionsAcrossEntities(filters.getUserId(), filters.getStartDate(), filters.getEndDate());
-            return new PaginatedAuditResult(audits, totalCount);
+    List<AuditEntity<?>> audits = auditService.getAllRevisionsAcrossEntitiesWithEntityType(
+            page, size, filters.getUserId(), filters.getStartDate(), filters.getEndDate(), null, sortOrder);
+    long totalCount = auditService.countRevisionsAcrossEntitiesWithEntityType(
+            filters.getUserId(), filters.getStartDate(), filters.getEndDate(), null);
+    return new PaginatedAuditResult(audits, totalCount);
         }
-    }
+}
 
     /**
      * Parses raw filter input strings into an AuditFilter object.

--- a/omod/src/main/webapp/auditlogs.jsp
+++ b/omod/src/main/webapp/auditlogs.jsp
@@ -25,21 +25,30 @@
                 />
             </div>
             <div class="filter-field">
-                <label for="startDate" class="filter-label">From:</label>
-                <input type="date" id="startDate" name="startDate" value="${param.startDate}">
-            </div>
-            <div class="filter-field">
-                <label for="endDate" class="filter-label">To:</label>
-                <input type="date" id="endDate" name="endDate" value="${param.endDate}">
-            </div>
-            <div class="filter-field">
-                <label for="sortOrder" class="filter-label">Sort By:</label>
-                <select id="sortOrder" name="sortOrder">
-                    <option value="desc" <c:if test="${sortOrder == null || sortOrder == 'desc'}">selected</c:if>>Descending</option>
-                    <option value="asc" <c:if test="${sortOrder == 'asc'}">selected</c:if>>Ascending</option>
-                </select>
-            </div>
-        </div>
+    <label for="startDate" class="filter-label">From:</label>
+    <input type="date" id="startDate" name="startDate" value="${param.startDate}">
+</div>
+<div class="filter-field">
+    <label for="endDate" class="filter-label">To:</label>
+    <input type="date" id="endDate" name="endDate" value="${param.endDate}">
+</div>
+<div class="filter-field">
+    <label for="action" class="filter-label">Action:</label>
+    <select id="action" name="action">
+        <option value="" <c:if test="${empty param.action}">selected</c:if>>All</option>
+        <option value="ADD" <c:if test="${param.action == 'ADD'}">selected</c:if>>Created</option>
+        <option value="MOD" <c:if test="${param.action == 'MOD'}">selected</c:if>>Modified</option>
+        <option value="DEL" <c:if test="${param.action == 'DEL'}">selected</c:if>>Deleted</option>
+    </select>
+</div>
+<div class="filter-field">
+    <label for="sortOrder" class="filter-label">Sort By:</label>
+    <select id="sortOrder" name="sortOrder">
+        <option value="desc" <c:if test="${sortOrder == null || sortOrder == 'desc'}">selected</c:if>>Descending</option>
+        <option value="asc" <c:if test="${sortOrder == 'asc'}">selected</c:if>>Ascending</option>
+    </select>
+</div>
+</div>
 
         <div class="search-group">
             <label for="entitySearch" class="search-label">Search and Select an Entity:</label>


### PR DESCRIPTION
## Description of what I changed
The audit log search was inconvenient to use- the sort order was hardcoded 
to descending in the REST API, there was no way to filter by action type 
(Created/Modified/Deleted), and the entity search input was read-only making 
it hard to type and find entities quickly.

Changes made:
- Added `sortOrder` parameter to the REST API (defaults to "desc") so callers 
  can request ascending or descending results
- Added `action` parameter to the REST API to filter logs by revision type 
  (ADD, MOD, DEL)
- Added validation for the `sortOrder` parameter- returns 400 Bad Request 
  for invalid values
- Added a Revision Type dropdown to the UI filter form so users can filter 
  by Created, Modified, or Deleted directly from the page

## Issue I worked on
see https://openmrs.atlassian.net/browse/AUDIT-32

## Checklist: I completed these to help reviewers :)
- [x] My IDE is configured to follow the code style of this project.
- [x] I have added tests to cover my changes.
- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.
- [x] All new and existing tests passed.
- [x] My pull request is based on the latest changes of the master branch.