### PR TITLE
AUDIT-51 : Username filter returns default result for Unknown users

### DIFF
--- a/omod/src/main/java/org/openmrs/module/auditlogweb/rest/AuditLogRestController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/rest/AuditLogRestController.java
@@ -77,9 +77,16 @@ public class AuditLogRestController {
         if (page < 0) page = 0;
         if (size <= 0) size = 20;
 
-        Integer effectiveUserId = resolveUserId(userId, username);
         Date start = parseDate(startDate);
         Date end = parseDate(endDate);
+
+        Integer effectiveUserId = userId;
+        if (effectiveUserId == null && username != null && !username.isEmpty()) {
+            effectiveUserId = resolveUserIdFromUsername(username);
+            if (effectiveUserId == null) {
+                return new AuditLogResponseDto(0, page, 0, Collections.emptyList());
+            }
+        }
 
         boolean fullDetails = userId != null || username != null || startDate != null || endDate != null || entityType != null;
 
@@ -115,12 +122,8 @@ public class AuditLogRestController {
         }
     }
 
-    private Integer resolveUserId(Integer userId, String username) {
-        if (userId != null) return userId;
-        if (username != null && !username.isEmpty()) {
-            User u = Context.getUserService().getUserByUsername(username);
-            if (u != null) return u.getUserId();
-        }
-        return null;
+    private Integer resolveUserIdFromUsername(String username) {
+        User user = Context.getUserService().getUserByUsername(username);
+        return user != null ? user.getUserId() : null;
     }
 }

--- a/omod/src/test/java/org/openmrs/module/auditlogweb/rest/AuditLogRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/auditlogweb/rest/AuditLogRestControllerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mockStatic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -134,6 +135,26 @@ public class AuditLogRestControllerTest {
                     .andExpect(status().isOk());
 
             verify(auditService).getAllRevisionsAcrossEntitiesWithEntityType(0, 20, 1, null, null, null, "desc");
+        }
+    }
+
+    @Test
+    public void shouldReturnEmptyResultForUnknownUsername() throws Exception {
+        try (MockedStatic<Context> contextMock = mockStatic(Context.class)) {
+            UserService userService = mock(UserService.class);
+            contextMock.when(() -> Context.getUserService()).thenReturn(userService);
+            when(userService.getUserByUsername("unknown")).thenReturn(null);
+
+            mockMvc.perform(get("/rest/v1/auditlogs")
+                            .param("username", "unknown"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.totalLogs", is(0)))
+                    .andExpect(jsonPath("$.currentPage", is(0)))
+                    .andExpect(jsonPath("$.totalPages", is(0)))
+                    .andExpect(jsonPath("$.logs", is(Collections.emptyList())));
+
+            verify(userService).getUserByUsername("unknown");
+            verifyNoInteractions(auditService);
         }
     }
 


### PR DESCRIPTION

## Description of what I changed
For the `/auditlogs` API , if there is unknown user on username filter then the API returns the all list or default result of audit logs instead of empty result,  and this change has fixed this issue.

## Issue I worked on
<!--- This project only accepts pull requests related to open issues -->
<!--- Want a new feature or change? Discuss it in an issue first! -->
<!--- Found a bug? Point us to the issue/or create one so we can reproduce it! -->
<!--- Just add the issue number at the end: -->
see https://openmrs.atlassian.net/browse/AUDIT-51

## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`