### PR TITLE
AUDIT-57: Add API to fetch audit entity types

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/AuditService.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/AuditService.java
@@ -10,6 +10,7 @@ package org.openmrs.module.auditlogweb.api;
 
 import org.openmrs.annotation.Authorized;
 import org.openmrs.module.auditlogweb.AuditEntity;
+import org.openmrs.module.auditlogweb.api.dto.AuditEntityTypeDto;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogDetailDTO;
 import org.openmrs.module.auditlogweb.api.utils.AuditLogConstants;
 
@@ -268,5 +269,16 @@ public interface AuditService {
      */
     @Authorized(AuditLogConstants.VIEW_AUDIT_LOGS)
     long countEntityAuditRevisionsById(Integer patientId, Class<?> entityClass);
+
+    /**
+     * Returns all Envers-audited entity types discovered on the classpath.
+     * <p>
+     * Each entry includes the simple class name (for use as the {@code entityType} REST filter)
+     * and the fully qualified class name.
+     *
+     * @return a sorted list of audited entity type descriptors
+     */
+    @Authorized(AuditLogConstants.VIEW_AUDIT_LOGS)
+    List<AuditEntityTypeDto> getAuditedEntityTypes();
 
 }

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/dto/AuditEntityTypeDto.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/dto/AuditEntityTypeDto.java
@@ -1,0 +1,30 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.auditlogweb.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Represents an Envers-audited entity type available for audit log filtering.
+ */
+@Data
+@AllArgsConstructor
+public class AuditEntityTypeDto {
+
+    /**
+     * The simple class name (e.g., "Patient"), used as the {@code entityType} REST filter value.
+     */
+    private String simpleName;
+
+    /**
+     * The fully qualified class name (e.g., "org.openmrs.Patient").
+     */
+    private String className;
+}

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/dto/AuditEntityTypesResponseDto.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/dto/AuditEntityTypesResponseDto.java
@@ -1,0 +1,24 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.auditlogweb.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+/**
+ * REST response wrapper for the list of audited entity types.
+ */
+@Data
+@AllArgsConstructor
+public class AuditEntityTypesResponseDto {
+
+    private List<AuditEntityTypeDto> entityTypes;
+}

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
@@ -18,6 +18,7 @@ import org.openmrs.api.impl.BaseOpenmrsService;
 import org.openmrs.module.auditlogweb.AuditEntity;
 import org.openmrs.module.auditlogweb.api.AuditService;
 import org.openmrs.module.auditlogweb.api.dao.AuditDao;
+import org.openmrs.module.auditlogweb.api.dto.AuditEntityTypeDto;
 import org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogDetailDTO;
 import org.openmrs.module.auditlogweb.api.dto.RelatedEntityDto;
@@ -25,6 +26,7 @@ import org.openmrs.module.auditlogweb.api.utils.UtilClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Date;
 import java.util.ArrayList;
@@ -458,6 +460,27 @@ public class AuditServiceImpl extends BaseOpenmrsService implements AuditService
 
     public long countEntityAuditRevisionsById(Integer patientId, Class<?> entityClass) {
         return auditDao.countRevisionsForEntityById(patientId, entityClass);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<AuditEntityTypeDto> getAuditedEntityTypes() {
+        return UtilClass.findClassesWithAnnotation().stream()
+                .map(className -> {
+                    try {
+                        Class<?> clazz = Class.forName(className);
+                        return new AuditEntityTypeDto(clazz.getSimpleName(), className);
+                    }
+                    catch (ClassNotFoundException e) {
+                        log.warn("Audited class not found on classpath: {}", className);
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .sorted(Comparator.comparing(AuditEntityTypeDto::getSimpleName, String.CASE_INSENSITIVE_ORDER))
+                .collect(Collectors.toList());
     }
 
 }

--- a/api/src/test/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImplTest.java
@@ -20,7 +20,9 @@ import org.openmrs.api.context.Context;
 import org.openmrs.api.db.hibernate.envers.OpenmrsRevisionEntity;
 import org.openmrs.module.auditlogweb.AuditEntity;
 import org.openmrs.module.auditlogweb.api.dao.AuditDao;
+import org.openmrs.module.auditlogweb.api.dto.AuditEntityTypeDto;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogDetailDTO;
+import org.openmrs.module.auditlogweb.api.utils.UtilClass;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -295,6 +297,22 @@ class AuditServiceImplTest {
                 1, null, null, "Patient");
 
         assertEquals(55L, count);
+    }
+
+    @Test
+    void shouldReturnAuditedEntityTypes() {
+        try (MockedStatic<UtilClass> utilClassMockedStatic = mockStatic(UtilClass.class)) {
+            utilClassMockedStatic.when(UtilClass::findClassesWithAnnotation)
+                    .thenReturn(Arrays.asList("org.openmrs.Patient", "org.openmrs.User"));
+
+            List<AuditEntityTypeDto> result = auditService.getAuditedEntityTypes();
+
+            assertEquals(2, result.size());
+            assertEquals("Patient", result.get(0).getSimpleName());
+            assertEquals("org.openmrs.Patient", result.get(0).getClassName());
+            assertEquals("User", result.get(1).getSimpleName());
+            assertEquals("org.openmrs.User", result.get(1).getClassName());
+        }
     }
 
     public static class TestEntity {

--- a/omod/src/main/java/org/openmrs/module/auditlogweb/rest/AuditLogRestController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/rest/AuditLogRestController.java
@@ -16,6 +16,7 @@ import org.openmrs.User;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.auditlogweb.AuditEntity;
 import org.openmrs.module.auditlogweb.api.AuditService;
+import org.openmrs.module.auditlogweb.api.dto.AuditEntityTypesResponseDto;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogDetailDTO;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogResponseDto;
 import org.openmrs.module.auditlogweb.api.utils.AuditLogConstants;
@@ -111,6 +112,16 @@ public class AuditLogRestController {
         int totalPages = (int) Math.ceil(total / (double) size);
 
         return new AuditLogResponseDto(Math.toIntExact(total), page, totalPages, auditDetails);
+    }
+
+    /**
+     * Returns all Envers-audited entity types available for audit log filtering.
+     *
+     * @return a list of entity type descriptors with simple and fully qualified class names
+     */
+    @GetMapping("/entityTypes")
+    public AuditEntityTypesResponseDto getEntityTypes() {
+        return new AuditEntityTypesResponseDto(auditService.getAuditedEntityTypes());
     }
 
     @GetMapping("/{revisionId}")

--- a/omod/src/test/java/org/openmrs/module/auditlogweb/rest/AuditLogRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/auditlogweb/rest/AuditLogRestControllerTest.java
@@ -20,6 +20,7 @@ import org.openmrs.User;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.auditlogweb.AuditEntity;
+import org.openmrs.module.auditlogweb.api.dto.AuditEntityTypeDto;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogDetailDTO;
 import org.openmrs.module.auditlogweb.api.utils.UtilClass;
 import org.openmrs.module.auditlogweb.api.AuditService;
@@ -28,8 +29,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.any;
@@ -303,6 +306,25 @@ public class AuditLogRestControllerTest {
                 eq(0), eq(20), eq(null), eq(expectedStartDate), eq(expectedEndDate), eq(null), eq("desc"));
         verify(auditService).countRevisionsAcrossEntitiesWithEntityType(
                 eq(null), eq(expectedStartDate), eq(expectedEndDate), eq(null));
+    }
+
+    @Test
+    public void shouldReturnEntityTypes() throws Exception {
+        List<AuditEntityTypeDto> entityTypes = Arrays.asList(
+                new AuditEntityTypeDto("Patient", "org.openmrs.Patient"),
+                new AuditEntityTypeDto("User", "org.openmrs.User")
+        );
+        when(auditService.getAuditedEntityTypes()).thenReturn(entityTypes);
+
+        mockMvc.perform(get("/rest/v1/auditlogs/entityTypes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.entityTypes.length()", is(2)))
+                .andExpect(jsonPath("$.entityTypes[0].simpleName", is("Patient")))
+                .andExpect(jsonPath("$.entityTypes[0].className", is("org.openmrs.Patient")))
+                .andExpect(jsonPath("$.entityTypes[1].simpleName", is("User")))
+                .andExpect(jsonPath("$.entityTypes[1].className", is("org.openmrs.User")));
+
+        verify(auditService).getAuditedEntityTypes();
     }
 
     @Test


### PR DESCRIPTION
## Description of what I changed

Added a REST endpoint to fetch available audit entity types dynamically.

Previously, entity types were only exposed to the legacy UI via `@ModelAttribute` in `AuditlogwebController`. REST clients had no way to discover valid `entityType` filter values and had to hardcode them.

This PR adds:
* **`GET /ws/rest/v1/auditlogs/entityTypes`** — returns all Envers-audited entity types discovered at runtime from the classpath (same source as the existing UI dropdown)
* **`AuditService.getAuditedEntityTypes()`** — service method with `@Authorized("View Audit Logs")` privilege enforcement
* **DTOs** — `AuditEntityTypeDto` and `AuditEntityTypesResponseDto`

### Example response
```json
{
  "entityTypes": [
    {
      "simpleName": "Patient",
      "className": "org.openmrs.Patient"
    },
    {
      "simpleName": "User",
      "className": "org.openmrs.User"
    }
  ]
}
```
* `simpleName` — use as the `entityType` query parameter on `GET /ws/rest/v1/auditlogs`
* `className` — fully qualified class name (matches legacy UI behavior)

Entity types are sorted alphabetically by `simpleName` (case-insensitive).

## Issue I worked on
See: https://openmrs.atlassian.net/browse/AUDIT-57

## Test plan
* [x] Run `mvn clean package` and confirm all tests pass
* [x] Deploy module to a running OpenMRS instance
* [x] Call `GET /openmrs/ws/rest/v1/auditlogs/entityTypes` with a user that has the **View Audit Logs** privilege and verify a `200 OK` response with a non-empty `entityTypes` list
* [x] Call the same endpoint without the privilege and verify authorization is enforced (`403` or authentication failure)
* [x] Pick a `simpleName` from the response (for example `Patient`) and verify `GET /openmrs/ws/rest/v1/auditlogs?entityType=Patient` works correctly

## Checklist: I completed these to help reviewers :)
* [x] My IDE is configured to follow the code style of this project.
* [x] I have added tests to cover my changes.
* [x] I ran `mvn clean package` right before creating this pull request and added all formatting changes to my commit.
* [x] All new and existing tests passed.
* [x] My pull request is based on the latest changes of the master branch.
