### PR TITLE
AUDIT-63: Fix username resolution and patient audit timeline

### DIFF
--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/AuditService.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/AuditService.java
@@ -275,6 +275,12 @@ public interface AuditService {
 	long countEntityAuditRevisionsById(Integer patientId, Class<?> entityClass);
 	
 	@Authorized(AuditLogConstants.VIEW_AUDIT_LOGS)
+	List<AuditEntity<?>> getPatientTimelineRevisions(Integer patientId, int page, int size, String sortOrder);
+	
+	@Authorized(AuditLogConstants.VIEW_AUDIT_LOGS)
+	long countPatientTimelineRevisions(Integer patientId);
+	
+	@Authorized(AuditLogConstants.VIEW_AUDIT_LOGS)
 	AuditEntityTypesResponseDto getAuditedEntitiesNames();
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/dao/AuditDao.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/dao/AuditDao.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Modifier;
 import java.sql.SQLSyntaxErrorException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.Date;
 import java.util.stream.Collectors;
@@ -552,6 +553,53 @@ public class AuditDao {
 				throw new AuditLogUnavailableException("Audit history could not be fetched, try again later", ex);
 			}
 		}
+	}
+	
+	public List<AuditEntity<?>> getAllRevisionsForEntityById(Integer entityId, Class<?> entityClass) {
+		return getRevisionsForEntityById(entityId, entityClass, 0, Integer.MAX_VALUE, "desc");
+	}
+	
+	public List<AuditEntity<?>> getRevisionsForOwnedEntities(Integer ownerId, Map<Class<?>, String> ownerPropertyByClass) {
+		List<AuditEntity<?>> result = new ArrayList<>();
+		if (ownerId == null || ownerPropertyByClass == null || ownerPropertyByClass.isEmpty()) {
+			return result;
+		}
+		
+		AuditReader auditReader = AuditReaderFactory.get(sessionFactory.getCurrentSession());
+		
+		for (Map.Entry<Class<?>, String> entry : ownerPropertyByClass.entrySet()) {
+			Class<?> ownedClass = entry.getKey();
+			String ownerProperty = entry.getValue();
+			try {
+				AuditQuery query = auditReader.createQuery().forRevisionsOfEntity(ownedClass, false, true)
+				        .add(org.hibernate.envers.query.AuditEntity.relatedId(ownerProperty).eq(ownerId));
+				
+				for (Object row : query.getResultList()) {
+					if (!(row instanceof Object[])) {
+						continue;
+					}
+					Object[] array = (Object[]) row;
+					Object entity = array[0];
+					OpenmrsRevisionEntity revisionEntity = (OpenmrsRevisionEntity) array[1];
+					RevisionType revisionType = (RevisionType) array[2];
+					if (entity != null) {
+						Integer userId = revisionEntity != null ? revisionEntity.getChangedBy() : null;
+						result.add(new AuditEntity<>(entity, revisionEntity, revisionType, userId));
+					}
+				}
+			}
+			catch (Exception ex) {
+				if (isMissingAuditTableException(ex)) {
+					log.warn("Skipping owned type {} in the timeline for owner {}: audit table missing ({})",
+					    ownedClass.getSimpleName(), ownerId, ex.getMessage());
+				} else {
+					log.error("Unexpected error fetching {} revisions for owner {}", ownedClass.getSimpleName(), ownerId,
+					    ex);
+				}
+			}
+		}
+		
+		return result;
 	}
 	
 	/**

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImpl.java
@@ -12,6 +12,7 @@ package org.openmrs.module.auditlogweb.api.impl;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.openmrs.GlobalProperty;
+import org.openmrs.Patient;
 import org.openmrs.Role;
 import org.openmrs.User;
 import org.openmrs.api.context.Context;
@@ -26,6 +27,7 @@ import org.openmrs.module.auditlogweb.api.dto.AuditEntityTypesResponseDto;
 import org.openmrs.module.auditlogweb.api.dto.AuditFieldDiff;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogDetailDTO;
 import org.openmrs.module.auditlogweb.api.dto.RelatedEntityDto;
+import org.openmrs.module.auditlogweb.api.utils.AuditLogConstants;
 import org.openmrs.module.auditlogweb.api.utils.UtilClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,6 +35,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Date;
@@ -169,11 +172,15 @@ public class AuditServiceImpl extends BaseOpenmrsService implements AuditService
 			return "Unknown";
 		}
 		
-		String username = user.getDisplayString();
-		if (StringUtils.isBlank(username)) {
-			return StringUtils.defaultIfBlank(user.getSystemId(), "Unknown");
+		if (StringUtils.isNotBlank(user.getUsername())) {
+			return user.getUsername();
 		}
-		return username;
+		if (StringUtils.isNotBlank(user.getSystemId())) {
+			return user.getSystemId();
+		}
+		
+		String personName = user.getPersonName() != null ? user.getPersonName().getFullName() : null;
+		return StringUtils.defaultIfBlank(personName, "Unknown");
 	}
 	
 	/**
@@ -473,6 +480,27 @@ public class AuditServiceImpl extends BaseOpenmrsService implements AuditService
 		return auditDao.getRevisionsForEntityById(patientId, entityClass, page, size, sortOrder);
 	}
 	
+	@Override
+	public List<AuditEntity<?>> getPatientTimelineRevisions(Integer patientId, int page, int size, String sortOrder) {
+		return UtilClass.paginate(collectPatientTimeline(patientId, sortOrder), page, size);
+	}
+	
+	@Override
+	public long countPatientTimelineRevisions(Integer patientId) {
+		return collectPatientTimeline(patientId, "desc").size();
+	}
+	
+	private List<AuditEntity<?>> collectPatientTimeline(Integer patientId, String sortOrder) {
+		List<AuditEntity<?>> merged = new ArrayList<>(auditDao.getAllRevisionsForEntityById(patientId, Patient.class));
+		merged.addAll(auditDao.getRevisionsForOwnedEntities(patientId, AuditLogConstants.PATIENT_OWNED_AUDITED_TYPES));
+		
+		Comparator<AuditEntity<?>> byChangedOn = Comparator.comparing(entity -> entity.getRevisionEntity().getChangedOn(),
+		    Comparator.nullsLast(Comparator.naturalOrder()));
+		merged.sort("asc".equalsIgnoreCase(sortOrder) ? byChangedOn : byChangedOn.reversed());
+		
+		return merged;
+	}
+	
 	public List<AuditLogDetailDTO> getEntityDetailedAudit(List<AuditEntity<?>> auditEntities, Class<?> entityClass) {
 		List<AuditLogDetailDTO> entityAudList = new ArrayList<>();
 		Map<String, String> displayCache = new HashMap<>();
@@ -485,14 +513,16 @@ public class AuditServiceImpl extends BaseOpenmrsService implements AuditService
 			
 			String entityId = UtilClass.getEntityIdAsString(currentEntity);
 			
-			List<AuditEntity<?>> allRelated = getRelatedEntitiesInRevision(entityClass, entityId,
+			Class<?> revisionClass = currentEntity.getClass();
+			
+			List<AuditEntity<?>> allRelated = getRelatedEntitiesInRevision(revisionClass, entityId,
 			    entity.getRevisionEntity().getId());
 			List<RelatedEntityDto> relatedEntities = new ArrayList<>();
 			
 			for (AuditEntity<?> related : allRelated) {
 				if (related.getEntity() != null) {
 					String relatedId = UtilClass.getEntityIdAsString(related.getEntity());
-					if (!related.getEntity().getClass().equals(entityClass) || !relatedId.equals(entityId)) {
+					if (!related.getEntity().getClass().equals(revisionClass) || !relatedId.equals(entityId)) {
 						relatedEntities.add(new RelatedEntityDto(related.getEntity().getClass().getName(),
 						        related.getEntity().getClass().getSimpleName(), relatedId,
 						        related.getRevisionEntity().getId(), related.getRevisionType()));

--- a/api/src/main/java/org/openmrs/module/auditlogweb/api/utils/AuditLogConstants.java
+++ b/api/src/main/java/org/openmrs/module/auditlogweb/api/utils/AuditLogConstants.java
@@ -9,6 +9,15 @@
  */
 package org.openmrs.module.auditlogweb.api.utils;
 
+import org.openmrs.PatientIdentifier;
+import org.openmrs.PersonAddress;
+import org.openmrs.PersonAttribute;
+import org.openmrs.PersonName;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 public final class AuditLogConstants {
 	
 	/* MODULE PRIVILEGES */
@@ -17,4 +26,20 @@ public final class AuditLogConstants {
 	public static final String VIEW_SECURITY_AUDIT_LOGS = "View Security Audit Logs";
 	
 	public static final String VIEW_READ_AUDIT_LOGS = "View Read Audit Logs";
+	
+	public static final Map<Class<?>, String> PATIENT_OWNED_AUDITED_TYPES;
+	
+	private static final String OWNER_PROPERTY_PERSON = "person";
+	
+	static {
+		Map<Class<?>, String> types = new LinkedHashMap<>();
+		types.put(PersonName.class, OWNER_PROPERTY_PERSON);
+		types.put(PersonAddress.class, OWNER_PROPERTY_PERSON);
+		types.put(PersonAttribute.class, OWNER_PROPERTY_PERSON);
+		types.put(PatientIdentifier.class, "patient");
+		PATIENT_OWNED_AUDITED_TYPES = Collections.unmodifiableMap(types);
+	}
+	
+	private AuditLogConstants() {
+	}
 }

--- a/api/src/test/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImplTest.java
+++ b/api/src/test/java/org/openmrs/module/auditlogweb/api/impl/AuditServiceImplTest.java
@@ -16,6 +16,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.MockitoAnnotations;
+import org.openmrs.Patient;
+import org.openmrs.PersonName;
 import org.openmrs.User;
 import org.openmrs.api.UserService;
 import org.openmrs.api.context.Context;
@@ -26,6 +28,7 @@ import org.openmrs.module.auditlogweb.api.AuditBackfillService;
 import org.openmrs.module.auditlogweb.api.dao.AuditDao;
 import org.openmrs.module.auditlogweb.api.dto.AuditEntityTypesResponseDto;
 import org.openmrs.module.auditlogweb.api.dto.AuditLogDetailDTO;
+import org.openmrs.module.auditlogweb.api.utils.AuditLogConstants;
 import org.openmrs.module.auditlogweb.api.utils.UtilClass;
 import org.openmrs.module.auditlogweb.api.utils.AuditSecurityEventType;
 
@@ -42,6 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -126,12 +130,12 @@ class AuditServiceImplTest {
 			UserService userService = mock(UserService.class);
 			User user = mock(User.class);
 			
-			when(user.getDisplayString()).thenReturn("Supper User (testuser)");
+			when(user.getUsername()).thenReturn("testuser");
 			context.when(Context::getUserService).thenReturn(userService);
 			when(userService.getUser(10)).thenReturn(user);
 			
 			String result = auditService.resolveUsername(10);
-			assertEquals("Supper User (testuser)", result);
+			assertEquals("testuser", result);
 		}
 	}
 	
@@ -479,7 +483,7 @@ class AuditServiceImplTest {
 			when(mockEntity.getChangedBy()).thenReturn(5);
 			doReturn(new TestEntity()).when(mockEntity).getEntity();
 			
-			when(user.getDisplayString()).thenReturn("Test User");
+			when(user.getUsername()).thenReturn("testuser");
 			context.when(Context::getUserService).thenReturn(userService);
 			when(userService.getUser(5)).thenReturn(user);
 			
@@ -492,7 +496,7 @@ class AuditServiceImplTest {
 			assertEquals(1, result.size());
 			
 			AuditLogDetailDTO dto = result.get(0);
-			assertEquals("Test User", dto.getChangedBy());
+			assertEquals("testuser", dto.getChangedBy());
 			
 			verify(userService).getUser(5);
 			
@@ -506,6 +510,94 @@ class AuditServiceImplTest {
 		
 		assertNotNull(result);
 		assertTrue(result.isEmpty());
+	}
+	
+	@Test
+	void shouldNotReturnDisplayStringWithNullUsername_GivenUserWithoutUsername() {
+		try (MockedStatic<Context> context = mockStatic(Context.class)) {
+			UserService userService = mock(UserService.class);
+			User user = mock(User.class);
+			
+			when(user.getUsername()).thenReturn(null);
+			when(user.getSystemId()).thenReturn("admin");
+			lenient().when(user.getDisplayString()).thenReturn("Super User (null)");
+			context.when(Context::getUserService).thenReturn(userService);
+			when(userService.getUser(11)).thenReturn(user);
+			
+			assertEquals("admin", auditService.resolveUsername(11));
+		}
+	}
+	
+	@Test
+	void shouldFallBackToPersonName_GivenNoUsernameOrSystemId() {
+		try (MockedStatic<Context> context = mockStatic(Context.class)) {
+			UserService userService = mock(UserService.class);
+			User user = mock(User.class);
+			PersonName personName = mock(PersonName.class);
+			
+			when(personName.getFullName()).thenReturn("Jane Doe");
+			when(user.getUsername()).thenReturn(null);
+			when(user.getSystemId()).thenReturn(null);
+			when(user.getPersonName()).thenReturn(personName);
+			context.when(Context::getUserService).thenReturn(userService);
+			when(userService.getUser(12)).thenReturn(user);
+			
+			assertEquals("Jane Doe", auditService.resolveUsername(12));
+		}
+	}
+	
+	private AuditEntity<?> revisionChangedOn(long epochMillis) {
+		AuditEntity<?> entity = mock(AuditEntity.class);
+		OpenmrsRevisionEntity revisionEntity = mock(OpenmrsRevisionEntity.class);
+		when(revisionEntity.getChangedOn()).thenReturn(new Date(epochMillis));
+		doReturn(revisionEntity).when(entity).getRevisionEntity();
+		return entity;
+	}
+	
+	@Test
+	void shouldMergePatientAndOwnedEntityRevisions_NewestFirst() {
+		AuditEntity<?> patientRevision = revisionChangedOn(2000);
+		AuditEntity<?> nameRevision = revisionChangedOn(3000);
+		AuditEntity<?> addressRevision = revisionChangedOn(1000);
+		
+		when(auditDao.getAllRevisionsForEntityById(7, Patient.class)).thenReturn(Collections.singletonList(patientRevision));
+		when(auditDao.getRevisionsForOwnedEntities(7, AuditLogConstants.PATIENT_OWNED_AUDITED_TYPES))
+		        .thenReturn(Arrays.asList(nameRevision, addressRevision));
+		
+		List<AuditEntity<?>> result = auditService.getPatientTimelineRevisions(7, 0, 10, "desc");
+		
+		assertEquals(3, result.size());
+		assertSame(nameRevision, result.get(0));
+		assertSame(patientRevision, result.get(1));
+		assertSame(addressRevision, result.get(2));
+	}
+	
+	@Test
+	void shouldSurfaceOwnedEntityRevisions_WhenPatientRowItselfNeverChanged() {
+		AuditEntity<?> nameRevision = revisionChangedOn(5000);
+		
+		when(auditDao.getAllRevisionsForEntityById(9, Patient.class)).thenReturn(Collections.emptyList());
+		when(auditDao.getRevisionsForOwnedEntities(9, AuditLogConstants.PATIENT_OWNED_AUDITED_TYPES))
+		        .thenReturn(Collections.singletonList(nameRevision));
+		
+		assertEquals(1, auditService.getPatientTimelineRevisions(9, 0, 10, "desc").size());
+		assertEquals(1, auditService.countPatientTimelineRevisions(9));
+	}
+	
+	@Test
+	void shouldPaginateTheMergedTimeline() {
+		List<AuditEntity<?>> patientRevisions = Arrays.asList(revisionChangedOn(4000), revisionChangedOn(3000));
+		List<AuditEntity<?>> ownedRevisions = Arrays.asList(revisionChangedOn(2000), revisionChangedOn(1000));
+		
+		when(auditDao.getAllRevisionsForEntityById(3, Patient.class)).thenReturn(patientRevisions);
+		when(auditDao.getRevisionsForOwnedEntities(3, AuditLogConstants.PATIENT_OWNED_AUDITED_TYPES))
+		        .thenReturn(ownedRevisions);
+		
+		assertEquals(4, auditService.countPatientTimelineRevisions(3));
+		assertEquals(2, auditService.getPatientTimelineRevisions(3, 0, 2, "desc").size());
+		List<AuditEntity<?>> secondPage = auditService.getPatientTimelineRevisions(3, 1, 2, "desc");
+		assertEquals(2, secondPage.size());
+		assertEquals(new Date(2000), secondPage.get(0).getRevisionEntity().getChangedOn());
 	}
 	
 	@Test

--- a/omod/src/main/java/org/openmrs/module/auditlogweb/rest/PatientLogRestController.java
+++ b/omod/src/main/java/org/openmrs/module/auditlogweb/rest/PatientLogRestController.java
@@ -66,12 +66,11 @@ public class PatientLogRestController {
 		
 		Integer patientId = patient.getPatientId();
 		
-		List<AuditEntity<?>> revisions = auditService.getEntityAuditRevisionsById(patientId, patient.getClass(), page, size,
-		    "desc");
+		List<AuditEntity<?>> revisions = auditService.getPatientTimelineRevisions(patientId, page, size, "desc");
 		
 		List<AuditLogDetailDTO> logs = auditService.getEntityDetailedAudit(revisions, patient.getClass());
 		
-		long total = auditService.countEntityAuditRevisionsById(patientId, patient.getClass());
+		long total = auditService.countPatientTimelineRevisions(patientId);
 		int totalPages = (int) Math.ceil(total / (double) size);
 		
 		return new AuditLogResponseDto(Math.toIntExact(total), page, totalPages, logs);

--- a/omod/src/test/java/org/openmrs/module/auditlogweb/rest/PatientLogRestControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/auditlogweb/rest/PatientLogRestControllerTest.java
@@ -77,15 +77,15 @@ public class PatientLogRestControllerTest {
 		when(mockPatient.getPatientId()).thenReturn(1);
 		when(patientService.getPatientByUuid("uuid-123")).thenReturn(mockPatient);
 		
-		when(auditService.getEntityAuditRevisionsById(1, Patient.class, 0, 20, "desc")).thenReturn(Collections.emptyList());
+		when(auditService.getPatientTimelineRevisions(1, 0, 20, "desc")).thenReturn(Collections.emptyList());
 		
 		when(auditService.getEntityDetailedAudit(any(), eq(Patient.class))).thenReturn(Collections.emptyList());
 		
-		when(auditService.countEntityAuditRevisionsById(1, Patient.class)).thenReturn(0L);
+		when(auditService.countPatientTimelineRevisions(1)).thenReturn(0L);
 		
 		mockMvc.perform(get("/rest/v1/auditlogs/patients").param("uuid", "uuid-123")).andExpect(status().isOk());
 		
-		verify(auditService).getEntityAuditRevisionsById(1, Patient.class, 0, 20, "desc");
+		verify(auditService).getPatientTimelineRevisions(1, 0, 20, "desc");
 	}
 	
 	@Test
@@ -94,13 +94,13 @@ public class PatientLogRestControllerTest {
 		when(mockPatient.getPatientId()).thenReturn(3);
 		when(patientService.getPatient(3)).thenReturn(mockPatient);
 		
-		when(auditService.getEntityAuditRevisionsById(3, Patient.class, 0, 20, "desc")).thenReturn(Collections.emptyList());
+		when(auditService.getPatientTimelineRevisions(3, 0, 20, "desc")).thenReturn(Collections.emptyList());
 		when(auditService.getEntityDetailedAudit(any(), eq(Patient.class))).thenReturn(Collections.emptyList());
-		when(auditService.countEntityAuditRevisionsById(3, Patient.class)).thenReturn(0L);
+		when(auditService.countPatientTimelineRevisions(3)).thenReturn(0L);
 		
 		mockMvc.perform(get("/rest/v1/auditlogs/patients").param("id", "3")).andExpect(status().isOk());
 		
-		verify(auditService).getEntityAuditRevisionsById(3, Patient.class, 0, 20, "desc");
+		verify(auditService).getPatientTimelineRevisions(3, 0, 20, "desc");
 	}
 	
 	@Test
@@ -109,14 +109,14 @@ public class PatientLogRestControllerTest {
 		when(mockPatient.getPatientId()).thenReturn(2);
 		when(patientService.getPatientByUuid("uuid-2")).thenReturn(mockPatient);
 		
-		when(auditService.getEntityAuditRevisionsById(2, Patient.class, 0, 20, "desc")).thenReturn(Collections.emptyList());
+		when(auditService.getPatientTimelineRevisions(2, 0, 20, "desc")).thenReturn(Collections.emptyList());
 		when(auditService.getEntityDetailedAudit(any(), eq(Patient.class))).thenReturn(Collections.emptyList());
-		when(auditService.countEntityAuditRevisionsById(2, Patient.class)).thenReturn(0L);
+		when(auditService.countPatientTimelineRevisions(2)).thenReturn(0L);
 		
 		mockMvc.perform(get("/rest/v1/auditlogs/patients").param("uuid", "uuid-2").param("page", "-3").param("size", "0"))
 		        .andExpect(status().isOk());
 		
-		verify(auditService).getEntityAuditRevisionsById(2, Patient.class, 0, 20, "desc");
+		verify(auditService).getPatientTimelineRevisions(2, 0, 20, "desc");
 	}
 	
 	@Test
@@ -125,13 +125,13 @@ public class PatientLogRestControllerTest {
 		when(mockPatient.getPatientId()).thenReturn(42);
 		when(patientService.getPatientByUuid("uuid-42")).thenReturn(mockPatient);
 		
-		when(auditService.getEntityAuditRevisionsById(42, Patient.class, 0, 20, "desc")).thenThrow(
+		when(auditService.getPatientTimelineRevisions(42, 0, 20, "desc")).thenThrow(
 		    new AuditLogUnavailableException("Audit history could not be fetched, try again later", new RuntimeException()));
 		
 		mockMvc.perform(get("/rest/v1/auditlogs/patients").param("uuid", "uuid-42"))
 		        .andExpect(status().isServiceUnavailable()).andExpect(jsonPath("$.error", is("Audit Log Unavailable")))
 		        .andExpect(jsonPath("$.message", is("Audit history could not be fetched, try again later")));
 		
-		verify(auditService, never()).countEntityAuditRevisionsById(anyInt(), any());
+		verify(auditService, never()).countPatientTimelineRevisions(anyInt());
 	}
 }


### PR DESCRIPTION
<!--- Add a pull request title above in this format -->
<!--- real example: 'AUDIT-10: Replace use of deprecated isVoided' -->
<!--- 'AUDIT-JiraIssueNumber: JiraIssueTitle' -->
## Description of what I changed
<!--- Describe your changes in detail -->
<!--- It can simply be your commit message, which you must have -->
  - Resolve audit usernames from `getUsername()`, then `getSystemId()`, then the person name, instead of `User#getDisplayString()`, which formats as `name (username)` and rendered the literal `Super User (null)` for the bundled admin account (the existing blank check could not catch it, since `"Super User (null)"` is not blank)
  - Add `getPatientTimelineRevisions()`/`countPatientTimelineRevisions()` to AuditService: merge the patient's own revisions with revisions of the person-subordinate types (`PersonName`, `PersonAddress`, `PersonAttribute`, `PatientIdentifier`), matched on their owning person/patient via `AuditEntity.relatedId()`
  - Sort and paginate the merged timeline as a single list, since paging each entity type separately slices each type rather than the combined history
  - Add `getAllRevisionsForEntityById()` and `getRevisionsForOwnedEntities()` to AuditDao, skipping an owned type whose audit table is missing rather than blanking the whole timeline
  - Derive the entity type per revision in `getEntityDetailedAudit()`, as a patient timeline mixes `Patient` rows with the owned types
  - Point PatientLogRestController at the merged timeline, so `/auditlogs/patients` no longer hides changes that never touch the patient row: voiding a name writes only `person_name_AUD` and left `patient_AUD` untouched, making it invisible in the patient's history
  - Update the two `resolveUsername` tests that already described this behaviour (they stub `getUsername()`/`getSystemId()` and only passed because `getDisplayString()` was left unstubbed), and add tests for the merge, ordering and pagination

Verified against a RefApp SDK server with Envers enabled: `Changed by` now reads `admin` across all 44 Patient revisions, and after adding a name to a patient and voiding it, the Audit History tab shows the Created/Updated/Voided revisions for that name, with `/auditlogs/patients` returning entity types `["PersonName", "Patient"]` where it previously returned only `Patient`.

## Issue I worked on
see https://openmrs.atlassian.net/browse/AUDIT-63




## Checklist: I completed these to help reviewers :)
<!--- Put an `x` in the box if you did the task -->
<!--- If you forgot a task please follow the instructions below -->
- [x] My IDE is configured to follow the [**code style**](https://wiki.openmrs.org/display/docs/Java+Conventions) of this project.

  No? Unsure? -> [configure your IDE](https://wiki.openmrs.org/display/docs/How-To+Setup+And+Use+Your+IDE), format the code and add the changes with `git add . && git commit --amend`

- [x] I have **added tests** to cover my changes. (If you refactored
  existing code that was well tested you do not have to add tests)

  No? -> write tests and add them to this commit `git add . && git commit --amend`

- [x] I ran `mvn clean package` right before creating this pull request and
  added all formatting changes to my commit.

  No? -> execute above command

- [x] All new and existing **tests passed**.

  No? -> figure out why and add the fix to your commit. It is your responsibility to make sure your code works.

- [x] My pull request is **based on the latest changes** of the master branch.

  No? Unsure? -> execute command `git pull --rebase upstream master`
